### PR TITLE
Add vagrant vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
+.vagrant
 luks2crypt
 vendor
 tmp
 *.tar.gz
+*-cloudimg-console.log

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ through cgo to manage the encrypted devices. On debian/ubuntu you can run:
 
       go mod tidy
 
+- If you need a test enviornment the provided `Vagrantfile` creates an ubuntu
+  vm. The vagrantfile has a provision script that creates a luks disk image at
+  `/home/vagrant/luks-dev-disk.img`. The image is then encrypted with the password
+  "devpassword" and mounted at `/mnt`.
+
+      vagrant up       # create the dev vm
+      vagrant ssh      # connect to the consule of the vm
+      vagrant destroy  # delete the vm
 
 License
 -------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$create_luks_dev = <<-SCRIPT
+set -ux
+pushd /home/vagrant
+sudo umount /dev/mapper/luks-dev-disk
+sudo cryptsetup close luks-dev-disk
+rm -f luks-dev-disk.img
+fallocate -l 1G luks-dev-disk.img
+parted luks-dev-disk.img mklabel msdos --script
+echo "devpassword" | cryptsetup --batch-mode luksFormat luks-dev-disk.img
+echo "devpassword" | sudo cryptsetup open luks-dev-disk.img luks-dev-disk
+sudo mkfs.ext4 /dev/mapper/luks-dev-disk
+sudo mount /dev/mapper/luks-dev-disk /mnt
+
+echo "A dev luks disk has been created at /home/vagrant/luks-dev-disk.img"
+echo "The device has a password of \"devpassword\" and is mounted at /mnt"
+popd
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provision "shell",
+    inline: "apt install -y cryptsetup"
+
+  config.vm.provision "shell", privileged: false,
+    inline: $create_luks_dev
+end


### PR DESCRIPTION
Adding an Ubuntu vagrant vm for interactive development testing. The vm auto-provisions a 1GB disk image which is luks encrypted with the password "devpassword". The image is then mounted to `/mnt`.