### PR TITLE
Refactor hwinfo and add tests for package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 install: true
 script:
 - diff -u <(echo -n) <(gofmt -d .)
-- go test -v -x -ldflags "-X main.VERSION=${TRAVIS_TAG}"
+- go test -v -ldflags "-X main.VERSION=${TRAVIS_TAG}" ./...
 before_deploy:
 - mkdir -p tmp/luks2crypt
 - cp luks2crypt README.md COPYING LICENSE tmp/luks2crypt/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,9 @@ SCRIPT
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["setextradata", :id, "VBoxInternal/Devices/pcbios/0/Config/DmiSystemSerial", "string:1234foobar"]
+  end
 
   config.vm.provision "shell",
     inline: "apt install -y cryptsetup ssl-cert"

--- a/hwinfo/hwinfo_test.go
+++ b/hwinfo/hwinfo_test.go
@@ -1,0 +1,64 @@
+package hwinfo
+
+import (
+	"testing"
+)
+
+type FakeSystemInfo struct {
+	SerialNum, Hostname, Username string
+}
+
+func (i FakeSystemInfo) getSysSerialNumber() (string, error) {
+	return i.SerialNum, nil
+}
+
+func (i FakeSystemInfo) getHostname() (string, error) {
+	return i.Hostname, nil
+}
+
+func (i FakeSystemInfo) getUsername() (string, error) {
+	return i.Username, nil
+}
+
+func TestGetInfo(t *testing.T) {
+	expected := FakeSystemInfo{
+		SerialNum: "1234FooBar",
+		Hostname:  "testing.example.com",
+		Username:  "root",
+	}
+
+	actual, err := getInfo(expected)
+
+	if err != nil {
+		t.Errorf("failed to get system information: %v", err)
+	}
+
+	if actual.SerialNum != expected.SerialNum {
+		t.Errorf("expected serialnumber %v, instead got %v", expected.SerialNum, actual.SerialNum)
+	}
+
+	if actual.Hostname != expected.Hostname {
+		t.Errorf("expected hostname %v, instead got %v", expected.Hostname, actual.Hostname)
+	}
+
+	if actual.Username != expected.Username {
+		t.Errorf("expected username %v, instead got %v", expected.Username, actual.Username)
+	}
+}
+
+func TestNonrootGetInfo(t *testing.T) {
+	var expectedEmpty SystemInfo
+	expected := FakeSystemInfo{
+		Username: "testinguser",
+	}
+
+	actual, err := getInfo(expected)
+
+	if err == nil {
+		t.Errorf("checking for a non-root user should have returned an error")
+	}
+
+	if actual != expectedEmpty {
+		t.Errorf("expected actual to be empty. Got %v", actual)
+	}
+}


### PR DESCRIPTION
- Cleanup `hwinfo` to add interface. Should enable easier test writing
- Set vagrant vm bios serial number to '1234foobar'
- cleanup vars for errors
- add basic tests to `hwinfo` package