### PR TITLE
add makefile with test, build, clean, run, and deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-.git
-vendor

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .vagrant
 /luks2crypt
 /cryptservermock
-vendor
 tmp
 *.tar.gz
 *-cloudimg-console.log
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /go/src/github.com/square/luks2crypt
 COPY . .
 
 # go build and install luks2crypt
-RUN go install -ldflags "-X main.VERSION=${LUKS2CRYPT_VER}" -v ./cmd/...
+RUN make install
 
 # run and print the version of luks2crypt
 ENTRYPOINT [ "luks2crypt" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+VERSION := $(shell git describe --tags)
+
+BINPATH := ./bin
+
+GOCMD := go
+GOBUILD := $(GOCMD) build
+GOINSTALL := $(GOCMD) install
+GOCLEAN := $(GOCMD) clean
+GOTEST := $(GOCMD) test
+GOMOD := $(GOCMD) mod
+BINARY_NAME := luks2crypt
+MOCKSERVER_NAME := cryptservermock
+
+VAGRANTCMD := vagrant
+
+LDFLAGS=-ldflags "-X main.VERSION=$(VERSION)"
+
+all: test build
+
+install:
+	$(GOINSTALL) $(LDFLAGS) -v ./cmd/$(BINARY_NAME)
+
+build:
+	$(GOBUILD) $(LDFLAGS) -o $(BINPATH)/$(BINARY_NAME) -v ./cmd/$(BINARY_NAME)
+
+test:
+	$(GOTEST) -v ./...
+
+clean:
+	$(GOCLEAN)
+	rm -r ./bin
+
+deps:
+	$(GOMOD) tidy
+	$(GOCMD) get -u ./...
+
+build-mockserver:
+	$(GOCMD) build -o $(BINPATH)/$(MOCKSERVER_NAME) -v ./tools/cryptservermock
+
+mockserver: build-mockserver
+	sudo $(BINPATH)/$(MOCKSERVER_NAME)
+
+devup:
+	$(VAGRANTCMD) up
+
+devssh:
+	$(VAGRANTCMD) ssh
+
+devclean:
+	$(VAGRANTCMD) destroy --force

--- a/README.md
+++ b/README.md
@@ -54,36 +54,36 @@ through cgo to manage the encrypted devices. On debian/ubuntu you can run:
 
 - To prepare for a release by cleaning up the unused dependencies run:
 
-      go mod tidy
+      make deps
 
-- Standard go tools can be used to build luks2crypt:
+- Use the `Makefile` to test and build luks2crypt:
 
-      go build ./cmd/...
+      make
 
 - If you would like to use a mock crypt server to test client changes on is
   included in this project:
 
-      go build ./tools/...
+      make mockserver
 
 - If you need a test enviornment, the provided `Vagrantfile` creates an ubuntu
   vm. The vagrantfile has a provision script that creates a luks disk image at
   `/home/vagrant/luks-dev-disk.img`. The image is then encrypted with the password
   "devpassword" and mounted at `/mnt`.
 
-      vagrant up       # create the dev vm
-      vagrant ssh      # connect to the consule of the vm
-      vagrant destroy  # delete the vm
+      make devup       # create the dev vm
+      make devssh      # connect to the consule of the vm
+      make devclean    # delete the vm
 
   This also includes a mock implimentation of crypt-server to log the form
   data to stdout. You can launch the dev environment as follows:
 
-      vagrant up
-      vagrant ssh
-      sudo /vagrant/cryptservermock  # start the mock crypt-server
+      make devup
+      make devssh
+      sudo cryptservermock  # start the mock crypt-server
       
       # in a new term window test the client
-      vagrant ssh
-      sudo /vagrant/luks2crypt postimaging \
+      make devssh
+      sudo /vagrant/bin/luks2crypt postimaging \
         -l ./luks-dev-disk.img \
         -p devpassword \
         -s ubuntu-bionic:8443

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,8 +34,8 @@ SCRIPT
 
 $cryptservermock_install = <<-SCRIPT
 pushd /vagrant
-go build -v tools/cryptservermock/cryptservermock.go
-cp cryptservermock /usr/local/bin/
+make build-mockserver
+cp bin/cryptservermock /usr/local/bin/
 popd
 SCRIPT
 
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell",
-    inline: "apt install -y cryptsetup ssl-cert"
+    inline: "apt install -y cryptsetup ssl-cert make"
 
   config.vm.provision "shell", privileged: true,
     inline: $golang_install


### PR DESCRIPTION
Add `Makefile` to wrap typical development tasks. Updated readme, vagrantfile, and dockerfile to use make tasks. Currently, handles
- test
- build
- install
- mockserver build
- mockserver run
- vagrant up
- vagrant destroy
- vagrant ssh