### PR TITLE
use goreleaser to manage github release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ only-deploy-tags: &only-deploy-tags
     branches:
       ignore: /.*/
     tags:
-      only: /^v\d+\.\d+\.\d+$/
+      only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
 version: 2.1
 executors:
@@ -33,19 +33,10 @@ jobs:
     steps:
       - setup-image
       - run: make build
-      - run: make deploytar
-      - persist_to_workspace:
-          root: .
-          paths:
-            - artifacts
-      - store_artifacts:
-          path: artifacts
   publish-github-release:
     executor: golang
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - run: make deploy
 
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 *-cloudimg-console.log
 bin/
 artifacts/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,25 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=1
+    main: ./cmd/luks2crypt
+    goos:
+      - linux
+    goarch:
+      - amd64
+archives:
+  - replacements:
+      linux: Linux
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 VERSION := $(shell git describe --tags)
 
-OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-ARCH := $(shell dpkg --print-architecture)
-
-GITTAG := $(shell git describe --tags)
-
 BINPATH := ./bin
 
 GOCMD := go
@@ -28,14 +23,9 @@ install:
 build:
 	$(GOBUILD) $(LDFLAGS) -o $(BINPATH)/$(BINARY_NAME) -v ./cmd/$(BINARY_NAME)
 
-deploytar:
-	mkdir -p tmp/$(BINARY_NAME) artifacts
-	cp bin/$(BINARY_NAME) README.md COPYING LICENSE.txt tmp/$(BINARY_NAME)/
-	tar -C tmp -czvf artifacts/$(BINARY_NAME)-$(GITTAG)-$(OS)-$(ARCH).tar.gz $(BINARY_NAME)
-
 deploy:
-	GO111MODULE=off go get github.com/tcnksm/ghr
-	ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./artifacts/
+	go get github.com/goreleaser/goreleaser@latest
+	goreleaser release
 
 lint:
 	GO111MODULE=off go get -u golang.org/x/lint/golint
@@ -47,7 +37,7 @@ test:
 
 clean:
 	$(GOCLEAN)
-	rm -r ./bin ./tmp ./artifacts
+	rm -r ./bin ./tmp ./artifacts ./dist
 
 deps:
 	$(GOMOD) tidy

--- a/cmd/luks2crypt/main.go
+++ b/cmd/luks2crypt/main.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	// VERSION set during build
-	// go build -ldflags "-X main.VERSION=1.2.3"
-	VERSION = "0.0.1"
+	// version set during build
+	// go build -ldflags "-X main.version=1.2.3"
+	version = "0.0.1"
 )
 
 // run setups up cli arg handling and executes luks2crypt
@@ -28,7 +28,7 @@ func run(args []string) error {
 	app := cli.NewApp()
 	app.Name = "luks2crypt"
 	app.Usage = "Generates a random luks password, escrows it, and rotates slot 0 on root."
-	app.Version = VERSION
+	app.Version = version
 
 	app.Commands = []cli.Command{
 		{
@@ -66,7 +66,7 @@ func run(args []string) error {
 
 // optVersion returns the application version. Typically, this is the git sha
 func optVersion(c *cli.Context) error {
-	fmt.Println(VERSION)
+	fmt.Println(version)
 	return nil
 }
 


### PR DESCRIPTION
Switch from `ghr` to [`goreleaser`](https://goreleaser.com/) to build and deploy releases to github. This will also help automate deb builds for square/luks2crypt#8
