### PR TITLE
disable go modules for goreleaser install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ build:
 	$(GOBUILD) $(LDFLAGS) -o $(BINPATH)/$(BINARY_NAME) -v ./cmd/$(BINARY_NAME)
 
 deploy:
-	go get github.com/goreleaser/goreleaser@latest
-	goreleaser release
+	GO111MODULE=off go get github.com/goreleaser/goreleaser@latest
+	goreleaser release --rm-dist
 
 lint:
 	GO111MODULE=off go get -u golang.org/x/lint/golint


### PR DESCRIPTION
Disable usage of go modules during the `make deploy` `goreleaser` install step. Also, ensure `goreleaser` removes `dist/` before running.

square/luks2crypt#8
