### PR TITLE
fix: goreleaser archive replacements deprecation go1.21

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:0-1.20-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1.21",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,10 +9,6 @@ builds:
       - linux
     goarch:
       - amd64
-archives:
-  - replacements:
-      linux: Linux
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG LUKS2CRYPT_VER='7213ec6894a6f368375a290de81c17f56190c20e'
 
 # golang variables
 ARG GO111MODULE='on'
-ARG GOLANGVER='1.20.2'
-ARG GOLANGSHA="4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768"
+ARG GOLANGVER='1.21.5'
+ARG GOLANGSHA="e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e"
 ARG GOPATH='/go'
 ENV PATH=${PATH}:/usr/local/go/bin:/go/bin
 
@@ -21,7 +21,7 @@ RUN adduser --shell /bin/sh --system --group \
 RUN apt-get update && apt-get install -y \
       wget \
       ca-certificates \
-    && wget --no-verbose "https://dl.google.com/go/go${GOLANGVER}.linux-amd64.tar.gz" \
+    && wget --no-verbose "https://go.dev/dl/go${GOLANGVER}.linux-amd64.tar.gz" \
     && echo "${GOLANGSHA} *go${GOLANGVER}.linux-amd64.tar.gz" > go${GOLANGVER}.linux-amd64.tar.gz.shasum \
     && sha256sum -c go${GOLANGVER}.linux-amd64.tar.gz.shasum \
     && tar -C /usr/local -xzf go${GOLANGVER}.linux-amd64.tar.gz \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ through cgo to manage the encrypted devices. On debian/ubuntu you can run:
 
       make mockserver
 
-- If you need a test enviornment, the provided `Vagrantfile` creates an ubuntu
+- If you need a test environment, the provided `Vagrantfile` creates an ubuntu
   vm. The vagrantfile has a provision script that creates a luks disk image at
   `/home/vagrant/luks-dev-disk.img`. The image is then encrypted with the password
   "devpassword" and mounted at `/mnt`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@
 
 $golang_install = <<-SCRIPT
 set -ux
-GOLANGVER=1.20.2
-GOLANGTAR=https://dl.google.com/go/go${GOLANGVER}.linux-amd64.tar.gz
+GOLANGVER=1.21.5
+GOLANGTAR=https://go.dev/dl/go${GOLANGVER}.linux-amd64.tar.gz
 
 pushd /tmp
 rm -rf /usr/local/go /tmp/go*.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/square/luks2crypt
 
-go 1.20
+go 1.21
 
 require (
 	github.com/diskfs/go-diskfs v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/dselans/dmidecode v0.0.0-20180814053009-65c3f9d81910/go.mod h1:yGxJ4z
 github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab h1:h1UgjJdAAhj+uPL68n7XASS6bU+07ZX1WJvVS2eyoeY=
 github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/schema v1.2.1 h1:tjDxcmdb+siIqkTNoV+qRH2mjYdr2hHe5MKXbp61ziM=


### PR DESCRIPTION
- Fix goreleaser config deprecations to address removal of `archives.replacements`
- Upgrade go from 1.20 to 1.21.5