### PR TITLE
fix: goreleaser go1.21 and fix artifact template for deprecation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
 
       - name: Install dependencies
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod tidy
+    - go generate ./...
 builds:
   - env:
       - CGO_ENABLED=1
@@ -9,6 +10,20 @@ builds:
       - linux
     goarch:
       - amd64
+archives:
+  - builds_info:
+      group: root
+      owner: root
+    wrap_in_directory: true
+    format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
- Run goreleaser in go 1.21 (stable).
- Add goreleaser artifact naming template to keep package names the same
- Ensure files in artifact archive are owned root:root with a parent directory.