### PR TITLE
feat: add dependabot updates for actions and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,5 +21,8 @@
 	// "remoteUser": "root"
 
 	// install development dependencies for cgo
-	"postCreateCommand": "sudo apt update && sudo apt install --yes libcryptsetup-dev && git config --global --add safe.directory /workspaces/luks2crypt"
+	"postCreateCommand": "sudo apt update && sudo apt install --yes libcryptsetup-dev && git config --global --add safe.directory /workspaces/luks2crypt",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	}
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@
 
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
Enable dependabot updates for github actions and devcontainers. Also,
adds gh cli to the devcontainer.