### PR TITLE
fix: attempt to fix codeql by installing deps

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -41,6 +41,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y libcryptsetup-dev
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Codeql ci is currently failing. This might be because the workflow
is missing the c library needed to build luks2crypt. This installs
the dev libs for cryptsetup before running codeql. It also sets up
the go version in `go.mod` to ensure the toolchain is available.