### PR TITLE
fix: add go patch version 1.22.0 to go.mod for toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/square/luks2crypt
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/diskfs/go-diskfs v1.4.0


### PR DESCRIPTION
Fixes a warning with codeql where the go patch version was not specified in `go.mod`. This adds the go patch version for go in the devcontainer.