### PR TITLE
fix: update goreleaser to v2, use supported action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: simple
 
@@ -40,10 +40,10 @@ jobs:
           sudo apt update && sudo apt install -y libcryptsetup-dev
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/square/luks2crypt
 
-go 1.22.0
+go 1.22.3
 
 require (
 	github.com/diskfs/go-diskfs v1.4.0


### PR DESCRIPTION
- Update goreleaser to v2
- Update goreleaser action to v6. Replaces #111
- Update relase-please to supported version which was migrated to `googleapis`
  project.
- Update go minor version to 1.22.3