### PR TITLE
ci: declare contents:read on Test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
The `Test` workflow installs `libcryptsetup-dev`, then runs `make lint` and `make test` against the Go matrix. No GitHub API write, no comment-on-PR step.

This patch pins it to `permissions: contents: read` at workflow scope. The style is already idiomatic in this repo:

- `codeql.yaml` -- per-job `actions: read, contents: read, security-events: write`
- `release.yaml` -- workflow-level `contents: write, pull-requests: write`

With explicit scope:

- the workflow token can't be widened by a future change to the repository default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `actions/setup-go` (cf. tj-actions/changed-files CVE-2025-30066) stays boxed in read-only

No behavioural change.