### PR TITLE
fix(ci): disable setup-go cache for tags

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -48,6 +48,8 @@ jobs:
 
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
       with:
+        # only enable the cache if the ref is not a tag
+        cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
         go-version-file: 'go.mod'
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
+          # only enable the cache if the ref is not a tag
+          cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           go-version: 'stable'
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
       with:
+        # only enable the cache if the ref is not a tag
+        cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
         go-version: ${{ matrix.go-version }}
 
     - name: Install dependencies


### PR DESCRIPTION
Disable setup go caching for tags. This will help
prevent using a poisoned cache on tagged releases.