### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/square/luks2crypt/security/code-scanning/7](https://github.com/square/luks2crypt/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/test.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, `contents: read` is the minimal and appropriate permission based on current steps (`checkout`, setup, lint, test). This preserves functionality while enforcing least privilege and satisfying CodeQL.

Edit region: immediately after the `on:` trigger block and before `jobs:`.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
